### PR TITLE
Add PHP 7.3 to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 sudo: false
-dist: trusty
 cache:
   directories:
     - $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
 php:
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 matrix:
   fast_finish: true


### PR DESCRIPTION
Alsom nighly is removed because phpunit requires php ^7.3, and php 8.0
does not satisfy it