### PR TITLE
Fix referencing dev dependency (vfsstream)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require-dev": {
     "phpunit/phpunit": "^6.5",
     "squizlabs/php_codesniffer": "^3.2",
-    "mikey179/vfsStream": "^1.6"
+    "mikey179/vfsstream": "^1.6"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Composer 2.0 requires package name to be lowercase