### PR TITLE
Fix PHP 8+ deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+[![PHP 7.2](https://img.shields.io/badge/PHP-7.2-8892BF.svg?logo=php)](https://php.net)
+
+# PR Filter
+
+Filter checkstyle.xml according to a diff
+
+## Usage
+
+```bash
+phpcs --report=checkstyle | sponge phpcs-checkstyle.xml
+git diff main > main.diff
+vendor/bin/prf filter-checkstyle main.diff phpcs-checkstyle.xml filtered-checkstyle.xml --base-path=$(pwd)
+```
+
+### Options
+
+`prf filter-checkstyle [-b|--base-path=] diff infile [outfile]`
+
+| Argument             |    | Description                                               |
+|----------------------|---------|-----------------------------------------------------------|
+| `--base-path`        | `-b`    | If set, will be removed from paths in checkstyle.xml      |
+| positional, required | diff    | Path to diff file         |
+| positional, required | infile  | Path to checkstyle.xml to be filtered                     |
+| positional, optional | outfile | Path to filtered checkstyle.xml, or will overwrite infile |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Filter checkstyle.xml according to a diff
 ## Usage
 
 ```bash
-phpcs --report=checkstyle | sponge phpcs-checkstyle.xml
+phpcs -q --report=checkstyle | sponge phpcs-checkstyle.xml
 git diff main > main.diff
 vendor/bin/prf filter-checkstyle main.diff phpcs-checkstyle.xml filtered-checkstyle.xml --base-path=$(pwd)
 ```

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -12,4 +12,4 @@ foreach ($possibleAutoloaders as $file) {
     }
 }
 
-return \DI\ContainerBuilder::buildDevContainer();
+return (new \DI\ContainerBuilder())->build();

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "keywords": ["filter", "diff", "checkstyle", "phpcs", "phan", "pull request"],
   "require": {
-    "php": "^7.1 || ^8.0",
+    "php": "^7.2 || ^8.0",
     "ptlis/diff-parser": "^1.0",
     "mnapoli/silly": "^1.7",
     "php-di/php-di": "^6.0.0"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "php-di/php-di": "^6.0 || ^7.1"
   },
   "require-dev": {
-    "phpunit/phpunit": "^6.5 || ^9.5",
+    "phpunit/phpunit": "^9.6 || ^10.5 || ^11.5",
     "squizlabs/php_codesniffer": "^3.2",
     "mikey179/vfsstream": "^1.6"
   },

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "php": "^7.2 || ^8.0",
     "ptlis/diff-parser": "^1.0",
     "mnapoli/silly": "^1.7",
-    "php-di/php-di": "^6.0.0"
+    "php-di/php-di": "^6.0 || ^7.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.5 || ^9.5",

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "keywords": ["filter", "diff", "checkstyle", "phpcs", "phan", "pull request"],
   "require": {
     "php": "^7.2 || ^8.0",
+    "ext-dom": "*",
     "ptlis/diff-parser": "^1.0",
     "mnapoli/silly": "^1.7",
     "php-di/php-di": "^6.0 || ^7.1"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,18 @@
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.2/phpunit.xsd"
-         beStrictAboutChangesToGlobalState="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
->
-    <filter>
-        <whitelist>
-            <directory suffix="php">src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        beStrictAboutChangesToGlobalState="true"
+        beStrictAboutOutputDuringTests="true"
+        beStrictAboutTestsThatDoNotTestAnything="true">
+  <coverage>
+    <include>
+      <directory suffix="php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="all">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Filesystem/FileException.php
+++ b/src/Filesystem/FileException.php
@@ -43,7 +43,7 @@ class FileException extends Exception
         );
     }
 
-    public static function readingFailed($filename, array $error = null): self
+    public static function readingFailed($filename, ?array $error = null): self
     {
         $error = (array) $error + ['message' => 'Unknown error'];
         return new self(

--- a/src/Xml/Node.php
+++ b/src/Xml/Node.php
@@ -12,7 +12,7 @@ class Node
     private $element;
     private $trailingWhitespace;
 
-    public function __construct(DOMElement $element, DOMText $whitespace = null)
+    public function __construct(DOMElement $element, ?DOMText $whitespace = null)
     {
         $this->element = $element;
         $this->trailingWhitespace = $whitespace;

--- a/tests/CheckstyleFilterTest.php
+++ b/tests/CheckstyleFilterTest.php
@@ -76,7 +76,7 @@ class CheckstyleFilterTest extends TestCase
         /** @var Loader|MockObject $loader */
         $loader = $this->getMockBuilder(Loader::class)
             ->disableOriginalConstructor()
-            ->setMethods(['loadFromFile'])
+            ->onlyMethods(['loadFromFile'])
             ->getMock();
 
         $loader->expects($this->once())

--- a/tests/DiffTest.php
+++ b/tests/DiffTest.php
@@ -190,7 +190,7 @@ class DiffTest extends TestCase
     private static function getFactory()
     {
         try {
-            return ContainerBuilder::buildDevContainer()->get(
+            return (new \DI\ContainerBuilder())->build()->get(
                 Factory::class
             );
         } catch (Exception $e) {

--- a/tests/Filesystem/FileExceptionTest.php
+++ b/tests/Filesystem/FileExceptionTest.php
@@ -53,7 +53,7 @@ class FileExceptionTest extends TestCase
         );
     }
 
-    public function emptyErrorsDataProvider()
+    public static function emptyErrorsDataProvider()
     {
         return [
             'null' => [null],

--- a/tests/Filesystem/FileTest.php
+++ b/tests/Filesystem/FileTest.php
@@ -102,7 +102,7 @@ class FileTest extends TestCase
 
         /** @var File|MockObject $mock */
         $mock = $this->getMockBuilder(File::class)
-            ->setMethods(['assertFileIsReadable'])
+            ->onlyMethods(['assertFileIsReadable'])
             ->setConstructorArgs([$file->url()])
             ->getMock();
 

--- a/tests/Xml/LoaderTest.php
+++ b/tests/Xml/LoaderTest.php
@@ -26,7 +26,7 @@ class LoaderTest extends TestCase
         /** @var MockObject|File $fileMock */
         $fileMock = $this->getMockBuilder(File::class)
             ->disableOriginalConstructor()
-            ->setMethods(['assertFileIsReadable'])
+            ->onlyMethods(['assertFileIsReadable'])
             ->getMock();
 
         $fileMock->expects($this->once())
@@ -34,7 +34,7 @@ class LoaderTest extends TestCase
 
         /** @var MockObject|FileFactory $fileFactoryMock */
         $fileFactoryMock = $this->getMockBuilder(FileFactory::class)
-            ->setMethods(['file'])
+            ->onlyMethods(['file'])
             ->getMock();
 
         $fileFactoryMock->expects($this->once())
@@ -59,7 +59,7 @@ class LoaderTest extends TestCase
         /** @var MockObject|File $fileMock */
         $fileMock = $this->getMockBuilder(File::class)
             ->disableOriginalConstructor()
-            ->setMethods(['assertFileIsReadable'])
+            ->onlyMethods(['assertFileIsReadable'])
             ->getMock();
 
         $fileMock->expects($this->once())
@@ -68,7 +68,7 @@ class LoaderTest extends TestCase
 
         /** @var MockObject|FileFactory $fileFactoryMock */
         $fileFactoryMock = $this->getMockBuilder(FileFactory::class)
-            ->setMethods(['file'])
+            ->onlyMethods(['file'])
             ->getMock();
 
         $fileFactoryMock->expects($this->once())


### PR DESCRIPTION
Hey,

This project looks great. But when I ran it under a newer PHP version, I saw lots of deprecation warnings.

* I don't think this project did actually work with PHP 7.1, because `ptlis/diff-parser` @ 1.0 [requires 7.2](https://github.com/ptlis/diff-parser/blob/f0f71287b57a6ce2beda15a256713e722e862f48/composer.json#L14)
* I updated `php-di/php-di` to 7.1 and had to replace `\DI\ContainerBuilder::buildDevContainer()` with `(new \DI\ContainerBuilder())->build()` but this appears to be backward compatible with PHP-DI 6.x
* There were two places in the `src` code that needed a `?` added to the parameter type
* When I updated PHPUnit to 10, it gave me a command to run to update its `phpunit.xml`, again this seems backwards compatible with 9.x. `MockBuilder::setMethods()` has been removed but `::onlyMethods()` seems to work ok. And `@dataProvider`s _must_ be static in PHPUnit 11
* And I added a short README with a "Usage" section

I've a couple of repos you might like: [php-codecoverage-markdown](https://github.com/BrianHenryIE/php-codecoverage-markdown), [php-diff-test](https://github.com/BrianHenryIE/php-diff-test).